### PR TITLE
[BFN] Added support for tofino3 profiles naming

### DIFF
--- a/config/plugins/barefoot.py
+++ b/config/plugins/barefoot.py
@@ -5,7 +5,7 @@ import json
 import subprocess
 from sonic_py_common import device_info
 from swsscommon.swsscommon import ConfigDBConnector
-from show.plugins.barefoot import check_profile, get_profile_format, get_chip_family
+from show.plugins.barefoot import check_profile, get_chip_family
 
 def abort_if_false(ctx, param, value):
     if not value:
@@ -14,16 +14,6 @@ def abort_if_false(ctx, param, value):
 @click.group()
 def barefoot():
     pass
-
-def check_profile_naming_tf3(profile, chip_family):
-    """Check if profile <profile_name>_<chip_family> exists"""
-    return subprocess.run(['docker', 'exec', '-it', 'syncd',
-        'test', '-d', '/opt/bfn/install_' + profile + '_' + chip_family])
-
-def check_profile_naming_tf2(profile):
-    """Check if profile <profile_name>_profile exists"""
-    return subprocess.run(['docker', 'exec', '-it', 'syncd',
-        'test', '-d', '/opt/bfn/install_' + profile + '_profile'])
 
 def check_supported_profile(profile, chip_family):
     """Check if profile is supported"""
@@ -34,19 +24,13 @@ def check_supported_profile(profile, chip_family):
 
 def check_profile_exist(profile, chip_family):
     """Check if profile exists"""
-    no_arch_information = False
-    completed_process = check_profile_naming_tf3(profile, chip_family)
-
-    if completed_process.returncode != 0:
-        if chip_family == 'tofino' or chip_family == 'tofino2':
-            completed_process = check_profile_naming_tf2(profile)
-            no_arch_information = True
+    completed_process = subprocess.run(['docker', 'exec', '-it', 'syncd',
+        'test', '-d', '/opt/bfn/install_' + profile + '_' + chip_family])
 
     if completed_process.returncode != 0:
         click.echo('No profile with the provided name found for {}'.format(chip_family))
         raise click.Abort()
-
-    return no_arch_information
+    return True
 
 @barefoot.command()
 @click.option('-y', '--yes', is_flag=True, callback=abort_if_false,
@@ -67,12 +51,12 @@ def profile(profile):
         raise click.Abort()
 
     # Check if profile exists
-    no_arch_information = check_profile_exist(profile, chip_family)
+    check_profile_exist(profile, chip_family)
 
     # Update configuration
     config_db = ConfigDBConnector()
     config_db.connect()
-    profile += '_profile' if no_arch_information else '_' + chip_family
+    profile += '_' + chip_family
     config_db.mod_entry('DEVICE_METADATA', 'localhost', {'p4_profile': profile})
     subprocess.run(['systemctl', 'restart', 'swss'], check=True)
 

--- a/show/platform.py
+++ b/show/platform.py
@@ -154,3 +154,10 @@ def firmware(args):
         subprocess.check_call(cmd, shell=True)
     except subprocess.CalledProcessError as e:
         sys.exit(e.returncode)
+
+# 'barefoot' subcommand ("show platform barefoot")
+@platform.command()
+def barefoot():
+    """Show Barefoot profile information"""
+    cmd = "barefoot profile"
+    clicommon.run_command(cmd)

--- a/show/plugins/barefoot.py
+++ b/show/plugins/barefoot.py
@@ -9,37 +9,70 @@ from sonic_py_common import device_info
 def barefoot():
     pass
 
-@barefoot.command()
-def profile():
-    # Check if profile can be changed
-    completed_process = subprocess.run(['docker', 'exec', '-it', 'syncd',
+def check_profile():
+    """Check if profile can be changed"""
+    ret = subprocess.run(['docker', 'exec', '-it', 'syncd',
         'test', '-h', '/opt/bfn/install'])
-    if completed_process.returncode != 0:
-        click.echo('Current profile: default')
-        return
-    
-    # Get chip family
+    if ret.returncode != 0:
+        return True
+    return False
+
+def get_chip_family():
+    """Get chip family"""
     hwsku_dir = device_info.get_path_to_hwsku_dir()
     with open(hwsku_dir + '/switch-tna-sai.conf') as file:
         chip_family = json.load(file)['chip_list'][0]['chip_family'].lower()
-    
+    return chip_family
+
+def get_current_profile():
+    """Get current profile"""
+    return subprocess.run('docker exec -it syncd readlink /opt/bfn/install | sed '
+            r's/install_\\\(.\*\\\)_profile/\\1/'
+            r' | sed s/install_\\\(.\*\\\)_tofino.\*/\\1/', check=True, shell=True)
+
+def get_profile_format(chip_family):
+    """Get profile naming format. Check if contains tofino family information"""
+    output = subprocess.check_output(['docker', 'exec', '-it', 'syncd', 'ls', '/opt/bfn']).strip().decode()
+    return '_' + chip_family if '_tofino' in output else '_profile'
+
+def get_available_profiles(opts):
+    """Get available profiles"""
+    return subprocess.run('docker exec -it syncd find /opt/bfn -mindepth 1 '
+        r'-maxdepth 1 -type d,l ' + opts + '| sed '
+        r's%/opt/bfn/install_\\\(.\*\\\)_profile%\\1%'
+        r' | sed s%/opt/bfn/install_\\\(.\*\\\)_tofino.\*%\\1%', shell=True)
+
+@barefoot.command()
+def profile():
+    # Check if profile can be changed
+    if check_profile():
+        click.echo('Current profile: default')
+        return
+
+    # Get chip family
+    chip_family = get_chip_family()
+
     # Print current profile
     click.echo('Current profile: ', nl=False)
-    subprocess.run('docker exec -it syncd readlink /opt/bfn/install | sed '
-        r's/install_\\\(.\*\\\)_profile/\\1/', check=True, shell=True)
-    
-    # Exclude current and unsupported profiles
+    current_profile = get_current_profile()
+    click.echo(current_profile.stdout, nl=False)
+
+    # Check if profile naming format contains tofino family information 
+    suffix = get_profile_format(chip_family)
+
+    # Check supported profiles 
     opts = ''
     if chip_family == 'tofino':
-        opts = r'\! -name install_y\*_profile '
+        opts = r' -name install_x\*' + suffix
     elif chip_family == 'tofino2':
-        opts = r'\! -name install_x\*_profile '
-    
+        opts = r' -name install_y\*' + suffix
+    else:
+        opts = r' -name \*' + suffix
+
     # Print profile list
     click.echo('Available profile(s):')
-    subprocess.run('docker exec -it syncd find /opt/bfn -mindepth 1 '
-        r'-maxdepth 1 -type d -name install_\*_profile ' + opts + '| sed '
-        r's%/opt/bfn/install_\\\(.\*\\\)_profile%\\1%', shell=True)
+    available_profiles = get_available_profiles(opts)
+    click.echo(available_profiles.stdout, nl=False)
 
 def register(cli):
     version_info = device_info.get_sonic_version_info()

--- a/tests/barefoot_test.py
+++ b/tests/barefoot_test.py
@@ -1,0 +1,203 @@
+import os
+import sys
+import textwrap
+import json
+from unittest.mock import patch, mock_open
+
+import pytest
+from click.testing import CliRunner
+import utilities_common.cli as cli
+
+import show.main as show
+import config.main as config
+import show.plugins.barefoot as bfshow
+import config.plugins.barefoot as bfconfig
+
+@pytest.fixture(scope='class')
+def config_env():
+    os.environ["UTILITIES_UNIT_TESTING"] = "1"
+    yield
+    os.environ["UTILITIES_UNIT_TESTING"] = "0"
+
+class TestStdout:
+    stdout = ""
+
+class TestReturncode:
+    returncode = False
+
+class TestShowPlatformBarefoot(object):
+
+    def test_config_barefoot(self):
+        runner = CliRunner()
+        expected_output = ""
+        result = CliRunner().invoke(show.cli.commands["platform"], ["barefoot"])
+        assert result.output == expected_output
+
+    def test_config_profile(self):
+        runner = CliRunner()
+        expected_output = "Swss service will be restarted, continue? [y/N]: \nAborted!\n"
+        result = runner.invoke(bfconfig.barefoot.commands['profile'], ['x1'])
+        print("result.exit_code:", result.exit_code)
+        print("result.output:", result.output)
+        assert result.output == expected_output
+
+    def test_check_profile_naming_tf3(self):
+        with patch('config.plugins.barefoot.subprocess.run', return_value=0):
+            result = bfconfig.check_profile_naming_tf3("y2", "tofino3")
+            assert result == 0
+
+    def test_check_profile_naming_tf2(self):
+        with patch('config.plugins.barefoot.subprocess.run', return_value=0):
+            result = bfconfig.check_profile_naming_tf2("y2")
+            assert result == 0
+
+    def test_check_profile_naming_tf3_t(self):
+        with patch('config.plugins.barefoot.subprocess.run', return_value=1):
+            result = bfconfig.check_profile_naming_tf3("y2", "tofino3")
+            assert result == 1
+
+    def test_check_profile_naming_tf2_t(self):
+        with patch('config.plugins.barefoot.subprocess.run', return_value=1):
+            result = bfconfig.check_profile_naming_tf2("y2")
+            assert result == 1
+
+    def test_check_profile_exist1(self):
+        completed_process = TestReturncode()
+        completed_process.returncode = 0
+        with patch('config.plugins.barefoot.check_profile_naming_tf3', return_value=completed_process):
+            result = bfconfig.check_profile_exist("x1", "tofino")
+            assert result == 0
+
+    def test_check_profile_exist2(self):
+        completed_process1  = TestReturncode() 
+        completed_process2  = TestReturncode()
+        completed_process1.returncode = 1
+        completed_process2.returncode = 0
+        with patch('config.plugins.barefoot.check_profile_naming_tf3', return_value=completed_process1):
+            with patch('config.plugins.barefoot.check_profile_naming_tf2', return_value=completed_process2):
+                result = bfconfig.check_profile_exist("x1", "tofino")
+                assert result == 1
+
+    def test_show_profile(self):
+        runner = CliRunner()
+        expected_output = "Current profile: default\n"
+        result = runner.invoke(bfshow.barefoot.commands['profile'], [])
+        print("result.exit_code:", result.exit_code)
+        print("result.output:", result.output)
+        assert result.output == expected_output
+
+    def test_get_chip_family1(self):
+        with patch('show.plugins.barefoot.device_info.get_path_to_hwsku_dir', return_value=""):
+            chip_family = json.dumps({"chip_list": [{"instance": 0,"chip_family": "tofino3"}]})
+            with patch('show.plugins.barefoot.open', mock_open(read_data=chip_family)):
+                result = bfshow.get_chip_family()
+                assert result == "tofino3"
+
+    def test_get_chip_family2(self):
+        with patch('config.plugins.barefoot.device_info.get_path_to_hwsku_dir', return_value=""):
+            chip_family = json.dumps({"chip_list": [{"instance": 0,"chip_family": "tofino3"}]})
+            with patch('show.plugins.barefoot.open', mock_open(read_data=chip_family)):
+                result = bfconfig.get_chip_family()
+                assert result == "tofino3"
+
+    def test_show_profile_default(self):
+        runner = CliRunner()
+        expected_output = "Current profile: default\n"
+        with patch("show.plugins.barefoot.check_profile", return_value=1):
+            print(show.plugins.barefoot.check_profile())
+            result = runner.invoke(bfshow.barefoot.commands['profile'], [])
+            print("result.exit_code:", result.exit_code)
+            print("result.output:", result.output)
+            assert result.output == expected_output
+
+    def test_check_profile1(self):
+        ret = TestReturncode()
+        ret.returncode = 1
+        with patch('show.plugins.barefoot.subprocess.run', return_value=ret):
+            result = bfshow.check_profile()
+            print(result)
+            assert result == True
+
+    def test_check_profile2(self):
+        ret = TestReturncode()
+        ret.returncode = 1
+        with patch('config.plugins.barefoot.subprocess.run', return_value=ret):
+            result = bfconfig.check_profile()
+            print(result)
+            assert result == True
+
+    def test_check_profile3(self):
+        ret = TestReturncode()
+        ret.returncode = 0
+        with patch('show.plugins.barefoot.subprocess.run', return_value=ret):
+            result = bfshow.check_profile()
+            print(result)
+            assert result == False
+
+    def test_check_profile4(self):
+        ret = TestReturncode()
+        ret.returncode = 0
+        with patch('config.plugins.barefoot.subprocess.run', return_value=ret):
+            result = bfconfig.check_profile()
+            print(result)
+            assert result == False
+
+    def test_check_supported_profile1(self):
+        result = bfconfig.check_supported_profile("x1", "tofino")
+        print(result)
+        assert result == True
+    
+    def test_check_supported_profile2(self):
+        result = bfconfig.check_supported_profile("y2", "tofino2")
+        print(result)
+        assert result == True
+
+    def test_check_supported_profile3(self):
+        result = bfconfig.check_supported_profile("x1", "tofino2")
+        print(result)
+        assert result == False
+
+    def test_check_supported_profile4(self):
+        result = bfconfig.check_supported_profile("y2", "tofino")
+        print(result)
+        assert result == False
+
+    def test_get_current_profile(self):
+        with patch('show.plugins.barefoot.subprocess.run', return_value="y2"):
+            result = bfshow.get_current_profile()
+            assert result == "y2"
+    
+    def test_get_profile_format(self):
+        with patch('show.plugins.barefoot.subprocess') as subprocess:
+            subprocess.return_value = 0
+            result = bfshow.get_profile_format("tofino")
+            assert result == "_profile"
+
+    def test_get_available_profiles(self):
+        with patch('show.plugins.barefoot.subprocess.run', return_value="x2"):
+            result = bfshow.get_available_profiles("install_x1_tofino")
+            assert result == "x2"
+
+    def test_show_profile(self):
+        runner = CliRunner()
+        expected_output = """\
+Current profile: y2
+Available profile(s):
+x1
+x2
+y2
+y3
+"""
+        with patch("show.plugins.barefoot.check_profile", return_value=False):
+            with patch("show.plugins.barefoot.get_chip_family", return_value="tofino"):
+                current_profile = TestStdout()
+                current_profile.stdout = "y2\n"
+                with patch("show.plugins.barefoot.get_current_profile", return_value=current_profile):
+                    with patch("show.plugins.barefoot.get_profile_format", return_value="_profile"):
+                        available_profile = TestStdout()
+                        available_profile.stdout = "x1\nx2\ny2\ny3\n"
+                        with patch("show.plugins.barefoot.get_available_profiles", return_value=available_profile):
+                            result = runner.invoke(bfshow.barefoot.commands['profile'], [])
+                            print("result.exit_code:", result.exit_code)
+                            print("result.output:", result.output)
+                            assert result.output == expected_output

--- a/tests/barefoot_test.py
+++ b/tests/barefoot_test.py
@@ -41,42 +41,12 @@ class TestShowPlatformBarefoot(object):
         print("result.output:", result.output)
         assert result.output == expected_output
 
-    def test_check_profile_naming_tf3(self):
-        with patch('config.plugins.barefoot.subprocess.run', return_value=0):
-            result = bfconfig.check_profile_naming_tf3("y2", "tofino3")
-            assert result == 0
-
-    def test_check_profile_naming_tf2(self):
-        with patch('config.plugins.barefoot.subprocess.run', return_value=0):
-            result = bfconfig.check_profile_naming_tf2("y2")
-            assert result == 0
-
-    def test_check_profile_naming_tf3_t(self):
-        with patch('config.plugins.barefoot.subprocess.run', return_value=1):
-            result = bfconfig.check_profile_naming_tf3("y2", "tofino3")
-            assert result == 1
-
-    def test_check_profile_naming_tf2_t(self):
-        with patch('config.plugins.barefoot.subprocess.run', return_value=1):
-            result = bfconfig.check_profile_naming_tf2("y2")
-            assert result == 1
-
-    def test_check_profile_exist1(self):
-        completed_process = TestReturncode()
-        completed_process.returncode = 0
-        with patch('config.plugins.barefoot.check_profile_naming_tf3', return_value=completed_process):
+    def test_check_profile_exist(self):
+        ret = TestReturncode()
+        ret.returncode = 0
+        with patch('show.plugins.barefoot.subprocess.run', return_value=ret):
             result = bfconfig.check_profile_exist("x1", "tofino")
-            assert result == 0
-
-    def test_check_profile_exist2(self):
-        completed_process1  = TestReturncode() 
-        completed_process2  = TestReturncode()
-        completed_process1.returncode = 1
-        completed_process2.returncode = 0
-        with patch('config.plugins.barefoot.check_profile_naming_tf3', return_value=completed_process1):
-            with patch('config.plugins.barefoot.check_profile_naming_tf2', return_value=completed_process2):
-                result = bfconfig.check_profile_exist("x1", "tofino")
-                assert result == 1
+            assert result == True
 
     def test_show_profile(self):
         runner = CliRunner()
@@ -163,18 +133,16 @@ class TestShowPlatformBarefoot(object):
         assert result == False
 
     def test_get_current_profile(self):
-        with patch('show.plugins.barefoot.subprocess.run', return_value="y2"):
+        profile = TestStdout()
+        profile.stdout = "y2"
+        with patch('show.plugins.barefoot.subprocess.run', return_value=profile):
             result = bfshow.get_current_profile()
             assert result == "y2"
-    
-    def test_get_profile_format(self):
-        with patch('show.plugins.barefoot.subprocess') as subprocess:
-            subprocess.return_value = 0
-            result = bfshow.get_profile_format("tofino")
-            assert result == "_profile"
 
     def test_get_available_profiles(self):
-        with patch('show.plugins.barefoot.subprocess.run', return_value="x2"):
+        profile = TestStdout()
+        profile.stdout = "x2"
+        with patch('show.plugins.barefoot.subprocess.run', return_value=profile):
             result = bfshow.get_available_profiles("install_x1_tofino")
             assert result == "x2"
 
@@ -190,14 +158,9 @@ y3
 """
         with patch("show.plugins.barefoot.check_profile", return_value=False):
             with patch("show.plugins.barefoot.get_chip_family", return_value="tofino"):
-                current_profile = TestStdout()
-                current_profile.stdout = "y2\n"
-                with patch("show.plugins.barefoot.get_current_profile", return_value=current_profile):
-                    with patch("show.plugins.barefoot.get_profile_format", return_value="_profile"):
-                        available_profile = TestStdout()
-                        available_profile.stdout = "x1\nx2\ny2\ny3\n"
-                        with patch("show.plugins.barefoot.get_available_profiles", return_value=available_profile):
-                            result = runner.invoke(bfshow.barefoot.commands['profile'], [])
-                            print("result.exit_code:", result.exit_code)
-                            print("result.output:", result.output)
-                            assert result.output == expected_output
+                with patch("show.plugins.barefoot.get_current_profile", return_value="y2\n"):
+                    with patch("show.plugins.barefoot.get_available_profiles", return_value="x1\nx2\ny2\ny3\n"):
+                        result = runner.invoke(bfshow.barefoot.commands['profile'], [])
+                        print("result.exit_code:", result.exit_code)
+                        print("result.output:", result.output)
+                        assert result.output == expected_output


### PR DESCRIPTION
Signed-off-by: Taras Keryk <tarasx.keryk@intel.com>

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Added support for tofino3 P4 profiles naming.
#### How I did it
Changed P4 profile naming format for support new tofino3 profiles. Added backward compatibility support for previous profile naming format.
#### How to verify it
The next commands should correctly work with the old and new profile naming format
```
show platform barefoot profile
```
and
```
config platform barefoot profile
```
#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

